### PR TITLE
Update WhitelistRangeMiddleware.php

### DIFF
--- a/src/Middleware/WhitelistRangeMiddleware.php
+++ b/src/Middleware/WhitelistRangeMiddleware.php
@@ -68,11 +68,16 @@ class WhitelistRangeMiddleware extends BaseMiddleware
     {
         $this->prepare($request);
 
+
         if ($this->isWhitelist()) {
             return true;
         }
 
         if (IpUtils::checkIp($this->ip(), config('filament-firewall.skip_whitelist_range', []))) {
+            return true;
+        }
+
+        if (!config('firewall.enabled', true)) {
             return true;
         }
 


### PR DESCRIPTION
When the firewall is disabled by setting FIREWALL_ENABLED=false and the WhitelistRangeMiddleware is in use, access to the panel is blocked. This update adds a check to ensure the firewall is enabled before applying restrictions. Note that this only impacts the panel if the middleware is applied in the Filament Panel Provider, which is a valid use case.